### PR TITLE
MERGE Add-rule-to-eslint-config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,5 +21,11 @@ module.exports = {
   plugins: ['react', '@typescript-eslint', 'prettier'],
   rules: {
     'react/react-in-jsx-scope': 0,
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Added
'prettier/prettier': [
  'error',
  {
    'endOfLine': 'auto',
  }
]
to ESLint config. This prevents a bunch of needless errors caused by prettier.