### PR TITLE
Add dependencies for sitting scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.10.4",
     "@fullcalendar/core": "^5.11.3",
     "@fullcalendar/daygrid": "^5.11.3",
+    "@fullcalendar/interaction": "^5.11.3",
     "@fullcalendar/react": "^5.11.2",
     "@mantine/carousel": "^5.2.6",
     "@mantine/core": "^5.2.6",

--- a/src/Components/Grids/SettingsGrid.tsx
+++ b/src/Components/Grids/SettingsGrid.tsx
@@ -6,6 +6,7 @@ import SittingSettingsWidget from '../Settings/SittingSettingsWidget';
 export default function SettingsGrid() {
   return (
     <>
+      <SittingScheduler />
       <SimpleGrid
         cols={2}
         breakpoints={[
@@ -19,7 +20,6 @@ export default function SettingsGrid() {
         <AreaSettingsWidget />
         <SittingSettingsWidget />
       </SimpleGrid>
-      <SittingScheduler />
     </>
   );
 }

--- a/src/Components/Scheduler/SittingScheduler.tsx
+++ b/src/Components/Scheduler/SittingScheduler.tsx
@@ -1,5 +1,5 @@
 import '@fullcalendar/react/dist/vdom';
-import FullCalendar from '@fullcalendar/react';
+import FullCalendar, { Interaction } from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 
 export default function SittingScheduler() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,6 +425,14 @@
     "@fullcalendar/common" "~5.11.3"
     tslib "^2.1.0"
 
+"@fullcalendar/interaction@^5.11.3":
+  version "5.11.3"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/interaction/-/interaction-5.11.3.tgz#c6712c1305ecb8e975953c7ff462222b49204187"
+  integrity sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==
+  dependencies:
+    "@fullcalendar/common" "~5.11.3"
+    tslib "^2.1.0"
+
 "@fullcalendar/react@^5.11.2":
   version "5.11.2"
   resolved "https://registry.yarnpkg.com/@fullcalendar/react/-/react-5.11.2.tgz#019e6a0573d869c2a52f63426e13593857ee2d30"


### PR DESCRIPTION
Added FullCalendar package and dependencies and generated basic diagram on settings page. FullCalendar can only be installed with yarn so there is also now a yarn package file.